### PR TITLE
chore: fix import-x/no-named-as-default-member warnings in qodana

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,7 @@ import reactHooksPlugin from 'eslint-plugin-react-hooks';
 import storybookPlugin from 'eslint-plugin-storybook';
 import unusedImportsPlugin from 'eslint-plugin-unused-imports';
 import globals from 'globals';
-import tseslint from 'typescript-eslint';
+import { configs as tsEslintConfigs, config } from 'typescript-eslint';
 
 const commonConfigs = {
   settings: { react: { version: 'detect' } },
@@ -20,7 +20,7 @@ const commonConfigs = {
 };
 
 const typeScriptConfigs = [
-  ...tseslint.configs.recommendedTypeChecked,
+  ...tsEslintConfigs.recommendedTypeChecked,
   {
     languageOptions: {
       globals: {
@@ -34,7 +34,7 @@ const typeScriptConfigs = [
   },
   {
     files: ['**/*.{js,jsx,mjs,cjs}'],
-    ...tseslint.configs.disableTypeChecked,
+    ...tsEslintConfigs.disableTypeChecked,
   },
   {
     files: ['**/*.{ts,tsx}'],
@@ -187,7 +187,7 @@ const storybookConfig = {
   },
 };
 
-export default tseslint.config(
+export default config(
   commonConfigs,
   eslint.configs.recommended,
   ...reactConfigs,

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path';
 
 import react from '@vitejs/plugin-react';
 import wyw from '@wyw-in-js/vite';
-import dotenv from 'dotenv';
+import { config } from 'dotenv';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
@@ -21,7 +21,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    env: dotenv.config({ path: '.env.test' }).parsed,
+    env: config({ path: '.env.test' }).parsed,
     server: {
       deps: {
         inline: ['next-auth'],


### PR DESCRIPTION
# what

* use a named export in eslint.config.mjs and vitest.config.mjs

# why

* to avoid warnings in qodana