### PR TITLE
ci: update qodana flow to avoid unnecessary run

### DIFF
--- a/.github/workflows/actions/get-changed-files/action.yml
+++ b/.github/workflows/actions/get-changed-files/action.yml
@@ -13,6 +13,12 @@ runs:
         files: |
           **/*.{js,jsx,ts,tsx,cjs,mjs,cts,mts}
         files_separator: "\n"
-    - name: Output changed files
-      run: echo ${{ steps.changed-files.outputs.all_changed_files }}
+    - name: List all changed files
+      env:
+        ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+      run: |
+        for file in ${ALL_CHANGED_FILES}; do
+          echo "$file was changed"
+        done
       shell: bash
+

--- a/.github/workflows/actions/get-changed-files/action.yml
+++ b/.github/workflows/actions/get-changed-files/action.yml
@@ -1,13 +1,11 @@
 outputs:
   any-changed:
     description: has files satisfy the specified condition
-    value: ${{ steps.any-changed.outputs }}
+    value: ${{ steps.changed-files.outputs.any-changed }}
 
 runs:
   using: composite
   steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
     - name: Get changed files
       uses: tj-actions/changed-files@v45.0.7
       id: changed-files
@@ -15,7 +13,3 @@ runs:
         files: |
           **/*.{js,jsx,ts,tsx,cjs,mjs,cts,mts}
         files_separator: "\n"
-    - name: Generate output
-      id: any-changed
-      run: echo "all_changed_files=${{ steps.changed-files.outputs.any-changed }}" >> $GITHUB_OUTPUTS
-      shell: bash

--- a/.github/workflows/actions/get-changed-files/action.yml
+++ b/.github/workflows/actions/get-changed-files/action.yml
@@ -13,3 +13,6 @@ runs:
         files: |
           **/*.{js,jsx,ts,tsx,cjs,mjs,cts,mts}
         files_separator: "\n"
+    - name: Show result
+      run: echo ${{ steps.changed-files.outputs.all-changed-files }}
+      shell: bash

--- a/.github/workflows/actions/get-changed-files/action.yml
+++ b/.github/workflows/actions/get-changed-files/action.yml
@@ -13,6 +13,6 @@ runs:
         files: |
           **/*.{js,jsx,ts,tsx,cjs,mjs,cts,mts}
         files_separator: "\n"
-    - name: Show result
-      run: echo ${{ steps.changed-files.outputs.all-changed-files }}
+    - name: Output changed files
+      run: echo ${{ steps.changed-files.outputs.all_changed_files }}
       shell: bash

--- a/.github/workflows/actions/get-changed-files/action.yml
+++ b/.github/workflows/actions/get-changed-files/action.yml
@@ -1,0 +1,22 @@
+outputs:
+  any-changed:
+    description: has files satisfy the specified condition
+    value: ${{ steps.any-changed.outputs }}
+
+runs:
+  using: composite
+  description: check if extensions of any changed files are js,jsx,ts,tsx,cjs,mjs,cts,mts
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Get changed files
+      uses: tj-actions/changed-files@v45.0.7
+      id: changed-files
+      with:
+        files: |
+          **/*.{js,jsx,ts,tsx,cjs,mjs,cts,mts}
+        files_separator: "\n"
+    - name: Generate output
+      id: any-changed
+      run: echo "all_changed_files=${{ steps.changed-files.outputs.any-changed }}" >> $GITHUB_OUTPUTS
+      shell: bash

--- a/.github/workflows/actions/get-changed-files/action.yml
+++ b/.github/workflows/actions/get-changed-files/action.yml
@@ -5,7 +5,6 @@ outputs:
 
 runs:
   using: composite
-  description: check if extensions of any changed files are js,jsx,ts,tsx,cjs,mjs,cts,mts
   steps:
     - name: Checkout code
       uses: actions/checkout@v3

--- a/.github/workflows/actions/qodana/action.yml
+++ b/.github/workflows/actions/qodana/action.yml
@@ -1,0 +1,10 @@
+runs:
+  using: composite
+  steps:
+    - name: 'Qodana Scan'
+      uses: JetBrains/qodana-action@v2024.3
+      with:
+        pr-mode: false
+      env:
+        QODANA_TOKEN: ${{ secrets.QODANA_TOKEN_1290658496 }}
+        QODANA_ENDPOINT: 'https://qodana.cloud'

--- a/.github/workflows/actions/test/action.yml
+++ b/.github/workflows/actions/test/action.yml
@@ -1,0 +1,6 @@
+runs:
+  using: composite
+  steps:
+    - name: Run Vitest
+      run: pnpm run test
+      shell: bash

--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0  # a full history is required for pull request analysis
       - name: Get changed files
         uses: ./.github/workflows/actions/get-changed-files
-        id: any_changed
+        id: check-changed-files
       - name: Run qodana code scanning
         uses: ./.github/workflows/actions/qodana
         if: ${{ steps.check-changed-files.outputs.any-changed }}

--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -8,25 +8,7 @@ on:
       - 'releases/*' # The release branches
 
 jobs:
-  get-changed-files:
-    runs-on: ubuntu-latest
-    outputs:
-      changed_files: ${{ steps.changed-files.outputs.all_changed_files }}
-      any_changed: ${{ steps.changed-files.outputs.any_changed }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Get changed files
-        uses: tj-actions/changed-files@v45.0.7
-        id: changed-files
-        with:
-          files: |
-            **/*.{js,jsx,ts,tsx,cjs,mjs,cts,mts}
-          files_separator: "\n"
-      - name: Output changed files
-        run: echo ${{ steps.changed-files.outputs.all_changed_files }}
   qodana:
-    needs: [ get-changed-files ]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -34,14 +16,13 @@ jobs:
       checks: write
     steps:
       - uses: actions/checkout@v4
+        name: Checkout
         with:
           ref: ${{ github.event.pull_request.head.sha }}  # to check out the actual pull request commit, not the merge commit
           fetch-depth: 0  # a full history is required for pull request analysis
-      - name: 'Qodana Scan'
-        if: needs.get-changed-files.outputs.any_changed == 'true'
-        uses: JetBrains/qodana-action@v2024.3
-        with:
-          pr-mode: false
-        env:
-          QODANA_TOKEN: ${{ secrets.QODANA_TOKEN_1290658496 }}
-          QODANA_ENDPOINT: 'https://qodana.cloud'
+      - name: Get changed files
+        uses: ./.github/workflows/actions/get-changed-files
+        id: any_changed
+      - name: Run qodana code scanning
+        uses: ./.github/workflows/actions/qodana
+        if: ${{ steps.check-changed-files.outputs.any-changed }}

--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -8,7 +8,25 @@ on:
       - 'releases/*' # The release branches
 
 jobs:
+  get-changed-files:
+    runs-on: ubuntu-latest
+    outputs:
+      changed_files: ${{ steps.changed-files.outputs.all_changed_files }}
+      any_changed: ${{ steps.changed-files.outputs.any_changed }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Get changed files
+        uses: tj-actions/changed-files@v45.0.7
+        id: changed-files
+        with:
+          files: |
+            **/*.{js,jsx,ts,tsx,cjs,mjs,cts,mts}
+          files_separator: "\n"
+      - name: Output changed files
+        run: echo ${{ steps.changed-files.outputs.all_changed_files }}
   qodana:
+    needs: [ get-changed-files ]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -20,6 +38,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}  # to check out the actual pull request commit, not the merge commit
           fetch-depth: 0  # a full history is required for pull request analysis
       - name: 'Qodana Scan'
+        if: needs.get-changed-files.outputs.any_changed == 'true'
         uses: JetBrains/qodana-action@v2024.3
         with:
           pr-mode: false

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -24,3 +24,7 @@ jobs:
         uses: ./.github/workflows/actions/init
       - name: Typecheck and lint
         uses: ./.github/workflows/actions/typecheck-and-lint
+      - name: Qodana check
+        uses: ./.github/workflows/actions/qodana
+      - name: Test
+        uses: ./.github/workflows/actions/test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         id: changed-files
         with:
           files: |
-            **/*.{js,jsx,ts,tsx,cjs,mjs,cts,mts}
+            src/**/*.{js,jsx,ts,tsx}
           files_separator: "\n"
       - name: Output changed files
         run: echo ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: vitest
+name: vitest]
 
 on:
   push:
@@ -15,32 +15,18 @@ permissions:
   contents: read
 
 jobs:
-  get-changed-files:
-    runs-on: ubuntu-latest
-    outputs:
-      changed_files: ${{ steps.changed-files.outputs.all_changed_files }}
-      any_changed: ${{ steps.changed-files.outputs.any_changed }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Get changed files
-        uses: tj-actions/changed-files@v45.0.7
-        id: changed-files
-        with:
-          files: |
-            src/**/*.{js,jsx,ts,tsx}
-          files_separator: "\n"
-      - name: Output changed files
-        run: echo ${{ steps.changed-files.outputs.all_changed_files }}
   test:
-    needs: [ get-changed-files ]
     name: Run test codes
     runs-on: ubuntu-latest
-    if: needs.get-changed-files.outputs.any_changed == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Check changed files
+        uses: ./.github/workflows/actions/get-changed-files
+        id: check-changed-files
       - name: Initialize
         uses: ./.github/workflows/actions/init
+        if: ${{ steps.check-changed-files.outputs.any-changed }}
       - name: Run Vitest
-        run: pnpm run test
+        uses: ./.github/workflows/actions/test
+        if: ${{ steps.check-changed-files.outputs.any-changed }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,28 @@ permissions:
   contents: read
 
 jobs:
+  get-changed-files:
+    runs-on: ubuntu-latest
+    outputs:
+      changed_files: ${{ steps.changed-files.outputs.all_changed_files }}
+      any_changed: ${{ steps.changed-files.outputs.any_changed }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Get changed files
+        uses: tj-actions/changed-files@v45.0.7
+        id: changed-files
+        with:
+          files: |
+            **/*.{js,jsx,ts,tsx,cjs,mjs,cts,mts}
+          files_separator: "\n"
+      - name: Output changed files
+        run: echo ${{ steps.changed-files.outputs.all_changed_files }}
   test:
+    needs: [ get-changed-files ]
     name: Run test codes
     runs-on: ubuntu-latest
+    if: needs.get-changed-files.outputs.any_changed == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: vitest]
+name: vitest
 
 on:
   push:

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  '*.{ts,tsx}': ['pnpm run lint:check', "bash -c 'pnpm run types:check'", 'pnpm run prettier:check'],
+  '*.{ts,tsx,mts,cts}': ['pnpm run lint:check', "bash -c 'pnpm run types:check'", 'pnpm run prettier:check'],
   '*': ['secretlint'],
 };


### PR DESCRIPTION
## what

- refine conditions for github actions to run
- reorganize each flow using composite workflow

## why

For renovate, all workflows should be run.
On the other hand, some workflows are not always required especially for pull requests pushed by human.
Therefore, some steps are extracted to composite workflows and reorganize flows using conditions to run.