### PR TITLE
ci: do not check public/mockServiceWorker

### DIFF
--- a/qodana.yaml
+++ b/qodana.yaml
@@ -6,3 +6,7 @@ profile:
 include:
   - name: CheckDependencyLicenses
   - name: Eslint
+exclude:
+  - name: All
+    paths:
+      - public/mockServiceWorker.js


### PR DESCRIPTION
Do not check public/mockServiceWorker.
This is code-generated file that always causes warnings in qodana report.