### PR TITLE
fix: exclude favicon from auth required list and fix redirect path

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,13 +1,14 @@
 import { NextResponse } from 'next/server';
 
 import { auth } from '~/auth';
+import { APP_HOST } from '~/config';
 
 export const config = {
-  matcher: ['/((?!api|_next/static|_next/image|login).+)'],
+  matcher: ['/((?!api|_next/static|_next/image|login|favicon).+)'],
 };
 
 export default auth((req) => {
   if (!req.auth) {
-    return NextResponse.redirect('http://localhost:3000/login');
+    return NextResponse.redirect(`${APP_HOST}/login`);
   }
 });


### PR DESCRIPTION
fix two issues in middleware
* access to favicon needs authorization
* redirect path does not respect APP_URL env