### PR TITLE
ci: add environment for release please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,6 +39,9 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
+    environment:
+      name: preview
+      url: ${{ steps.deploy.outputs.url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Deploy to production fails because the deploy workflow cannot access to github secret.

I tried some test cases and found that the workflow fails when environments of job are changed or missing.
I'm not sure this is real cause of the problem, but tentatively I added environment to deploy-production job to see if this solves the problem.