### PR TITLE
ci: remove deploy environment for preview

### DIFF
--- a/.github/workflows/deploy-non-production.yml
+++ b/.github/workflows/deploy-non-production.yml
@@ -12,9 +12,6 @@ jobs:
     name: Deploy preview
     runs-on: ubuntu-latest
     if: ${{ github.ref_name != 'main' && !startsWith(github.ref_name, 'release-please') }}
-    environment:
-      name: url
-      url: ${{ steps.deploy.outputs.url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-non-production.yml
+++ b/.github/workflows/deploy-non-production.yml
@@ -32,8 +32,8 @@ jobs:
     name: Deploy staging
     runs-on: ubuntu-latest
     environment:
-      name: preview
-      url: ${{ steps.deploy.outputs.url }}
+      name: Staging
+      url: ${{ steps.deploy-staging.outputs.url }}
     if: ${{ github.ref_name == 'main' }}
     steps:
       - name: Checkout

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,8 +40,8 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
     environment:
-      name: preview
-      url: ${{ steps.deploy.outputs.url }}
+      name: Production
+      url: ${{ steps.deploy-production.outputs.url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## what

- delete environment "preview"
- rename environment "Staging" and "Production"
- fix wrong url passed to environment

## why

After some research, I found out secrets are set as environment secrets instead of repository secret.
This is why the deploy action fails when production release or environment are changed or deleted (see #135).

Now vercel-related secrets are moved to repository secret and it is safe to make change on environment in workflow.