### PR TITLE
chore(vitest): move coverage settings from argument to vitest.config.mts

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "format:fix": "pnpm run lint:fix; pnpm run prettier:fix",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "test": "vitest --coverage.enabled",
+    "test": "vitest",
     "plop": "cross-env NODE_OPTIONS='--import tsx' plop --plopfile=plopfile.mts"
   },
   "dependencies": {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -19,6 +19,11 @@ export default defineConfig({
     }),
   ],
   test: {
+    coverage: {
+      enabled: true,
+      provider: 'v8',
+      include: ['src/**/*.{ts,tsx}'],
+    },
     environment: 'jsdom',
     globals: true,
     env: config({ path: '.env.test' }).parsed,


### PR DESCRIPTION
* move coverage report setting from argument of vitest command to vitest.config.mts
  * configs should not be located in separate locations